### PR TITLE
Corrected code in 5.4 Prediction.

### DIFF
--- a/01_introduction.Rmd
+++ b/01_introduction.Rmd
@@ -122,7 +122,7 @@ if (!dir.exists(gpkg_dir)) {
 f_ne <- file.path(gpkg_dir, "gis-data.gpkg")
 
 # download bcrs
-tmp_dir <- tempdir()
+tmp_dir <- normalizePath(tempdir())
 tmp_bcr <- file.path(tmp_dir, "bcr.zip")
 paste0("https://www.birdscanada.org/research/gislab/download/", 
        "bcr_terrestrial_shape.zip") %>% 

--- a/05_occupancy.Rmd
+++ b/05_occupancy.Rmd
@@ -265,7 +265,11 @@ In this section, we'll estimate the distribution of Wood Thrush in BCR 27. Simil
 Recall that when we [predicted encouter rate](#encounter-predict), we had to include effort variables in our prediction surface. We don't need to do that here because the occupancy submodel doesn't depend on the effort covariates, these only occur in the detection submodel.
 
 ```{r occupancy-predict-predict, eval = FALSE, results = "hold", echo = 1:9}
-system.time({
+
+if (.Platform$OS == "unix") {
+  Sys.time()
+} else {system.time()}
+
 occ_pred <- predict(occ_avg, 
                     newdata = as.data.frame(pred_surface), 
                     type = "state")


### PR DESCRIPTION
"system.time" wasn't working on macOS so I added a piece of code to make it work on macOS. Also, perhaps you want to take a look at the line of code right after 

```
# add to prediction surface
pred_occ <- bind_cols(pred_surface, 
                      occ_prob = occ_pred$fit, 
                      occ_se = occ_pred$se.fit) %>% 
```

as this part 

```
  select(latitude, longitude, occ_prob, occ_se)
saveRDS(pred_occ, "output/woothr_occupancy-model_predictions.rds")
```

is missing in the online version. 